### PR TITLE
refactor: migrate content collections to Astro v6 glob loader

### DIFF
--- a/.agents/brain/task.md
+++ b/.agents/brain/task.md
@@ -2,7 +2,7 @@
 okf_version: 0.1
 type: task_list
 title: "CMSForNerd2 Active Tasks"
-timestamp: "2026-07-30T12:00:00Z"
+timestamp: "2026-07-31T07:25:00Z"
 description: "Sovereign tracking list of active and completed tasks in this session."
 topics: [tasks, track, progress]
 ---
@@ -15,7 +15,10 @@ topics: [tasks, track, progress]
 - [x] Evaluate and compare static site generator (SSG) frameworks (selected Astro).
 - [x] Author comprehensive static migration guide in `docs/migration-guide.md`.
 - [x] Set up supporting repository structures (`README.md`, `START-HERE.md`, `SUMMARY.md`, `llms.txt`, `AGENTS.md`, and `.agents/AGENTS.md`).
-- [ ] Complete pre-commit checks and verification.
+- [x] Migrate `src/content/config.ts` to `src/content.config.ts` and update it to use the new glob loader API.
+- [x] Refactor rendering logic in `src/pages/[...slug].astro` and `src/pages/[...slug]/amp.astro` to use Astro v6 content collection rendering API (`render`).
+- [x] Verify complete local build and render/screenshot correctness of the home page via Playwright visual verification.
+- [x] Complete pre-commit checks and verification.
 - [ ] Submit changes.
 
 ---

--- a/.agents/brain/walkthrough.md
+++ b/.agents/brain/walkthrough.md
@@ -2,7 +2,7 @@
 okf_version: 0.1
 type: walkthrough
 title: "CMSForNerd2 Active Walkthrough"
-timestamp: "2026-07-30T12:00:00Z"
+timestamp: "2026-07-31T07:25:00Z"
 description: "Active record of steps and decisions made during the modernisation of CMSForNerd2."
 topics: [walkthrough, history, brain]
 ---
@@ -15,6 +15,8 @@ topics: [walkthrough, history, brain]
 2.  **SSG Framework Selection**: Selected Astro as the target framework due to its lightweight zero-JS output, support for modern CSS3/HTML5, robust content collections, and native View Transitions replacing legacy ajax routers.
 3.  **Migration Guide Compilation**: Created `docs/migration-guide.md` summarizing the exact transition playbook for the development team.
 4.  **Spatial Environment Configuration**: Set up root navigation and AI registries complying with DSOM rules.
+5.  **Astro v6 Content Collections Refactor**: Migrated `src/content/config.ts` to `src/content.config.ts` with the new glob loader, and refactored `[...slug].astro` and `amp.astro` to call `render(page)` instead of `page.render()`.
+6.  **Visual Verification**: Successfully ran a preview server on port 4321 and used Playwright to generate and inspect a pixel-perfect full-page screenshot of the homepage.
 
 ---
 *Deep State of Mind (DSOM) For My AI Protocol | Harisfazillah Jamel (LinuxMalaysia) | 2026-07-30*

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,8 @@
 import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
 
 const pagesCollection = defineCollection({
-  type: 'content',
+  loader: glob({ pattern: '**/*.md', base: './src/content/pages' }),
   schema: z.object({
     title: z.string(),
     description: z.string(),

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 import Layout from '../layouts/Layout.astro';
 
 export async function getStaticPaths() {
@@ -16,7 +16,7 @@ export async function getStaticPaths() {
 }
 
 const { page } = Astro.props;
-const { Content } = await page.render();
+const { Content } = await render(page);
 const slugValue = page.id.replace(/\.[^/.]+$/, "");
 ---
 

--- a/src/pages/[...slug]/amp.astro
+++ b/src/pages/[...slug]/amp.astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 import AmpLayout from '../../layouts/AmpLayout.astro';
 
 export async function getStaticPaths() {
@@ -16,7 +16,7 @@ export async function getStaticPaths() {
 }
 
 const { page } = Astro.props;
-const { Content } = await page.render();
+const { Content } = await render(page);
 const slugValue = page.id.replace(/\.[^/.]+$/, "");
 ---
 


### PR DESCRIPTION
By moving 'src/content/config.ts' to 'src/content.config.ts' and implementing the glob loader API, we successfully upgrade content collections configuration. Additionally, we refactor slug routes inside [...slug].astro and amp.astro to use 'render(page)' from 'astro:content' rather than the deprecated 'page.render()' method. This fully resolves compilation errors, allows standard/AMP pages to build successfully, and ensures compliance with DSOM and strict UK English requirements.

---
*PR created automatically by Jules for task [15060496703574057150](https://jules.google.com/task/15060496703574057150) started by @linuxmalaysia*