### PR TITLE
Customise Render.com deployment with NGINX and Astro 7.1

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,57 @@
+# ==============================================================================
+# Protocol    : Deep State of Mind (DSOM) For My AI
+# Author      : Harisfazillah Jamel (LinuxMalaysia)
+# Timestamp   : 2026-07-31
+# License     : GNU General Public License v3.0
+# Standard    : UK English | DBP-standard Bahasa Melayu Malaysia (Piawai)
+# ==============================================================================
+# =============================================================================
+# CMSForNerd2 v2.0.0 - Containerfile for Render Production Deployments (NGINX/Astro 7.1)
+# =============================================================================
+
+# Stage 1: Build environment
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy dependency definitions
+COPY package*.json ./
+
+# Install dependencies with legacy peer dependency resolution
+RUN npm install --legacy-peer-deps
+
+# Copy workspace source files
+COPY . .
+
+# Compile static assets
+RUN npm run build
+
+# Stage 2: Production runtime environment (NGINX Alpine Slim)
+FROM nginx:alpine-slim AS runtime
+
+# Copy custom unprivileged NGINX configuration
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+
+# Copy compiled static assets from builder stage
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Configure unprivileged execution directories and customise permissions
+RUN chown -R nginx:nginx /usr/share/nginx/html && \
+    chmod -R 755 /usr/share/nginx/html && \
+    mkdir -p /var/cache/nginx/client_temp \
+             /var/cache/nginx/proxy_temp \
+             /var/cache/nginx/fastcgi_temp \
+             /var/cache/nginx/uwsgi_temp \
+             /var/cache/nginx/scgi_temp && \
+    chown -R nginx:nginx /var/cache/nginx /var/run /var/log/nginx && \
+    touch /var/run/nginx.pid && \
+    chown nginx:nginx /var/run/nginx.pid
+
+# Switch to unprivileged nginx runtime user
+USER nginx
+
+# Expose unprivileged web port
+EXPOSE 8080
+
+# Run NGINX in foreground
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# ==============================================================================
+# Protocol    : Deep State of Mind (DSOM) For My AI
+# Author      : Harisfazillah Jamel (LinuxMalaysia)
+# Timestamp   : 2026-07-31
+# License     : GNU General Public License v3.0
+# Standard    : UK English | DBP-standard Bahasa Melayu Malaysia (Piawai)
+# ==============================================================================
+# =============================================================================
+# CMSForNerd2 v2.0.0 - Dockerfile for Render Production Deployments (NGINX/Astro 7.1)
+# =============================================================================
+
+# Stage 1: Build environment
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy dependency definitions
+COPY package*.json ./
+
+# Install dependencies with legacy peer dependency resolution
+RUN npm install --legacy-peer-deps
+
+# Copy workspace source files
+COPY . .
+
+# Compile static assets
+RUN npm run build
+
+# Stage 2: Production runtime environment (NGINX Alpine Slim)
+FROM nginx:alpine-slim AS runtime
+
+# Copy custom unprivileged NGINX configuration
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+
+# Copy compiled static assets from builder stage
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Configure unprivileged execution directories and customise permissions
+RUN chown -R nginx:nginx /usr/share/nginx/html && \
+    chmod -R 755 /usr/share/nginx/html && \
+    mkdir -p /var/cache/nginx/client_temp \
+             /var/cache/nginx/proxy_temp \
+             /var/cache/nginx/fastcgi_temp \
+             /var/cache/nginx/uwsgi_temp \
+             /var/cache/nginx/scgi_temp && \
+    chown -R nginx:nginx /var/cache/nginx /var/run /var/log/nginx && \
+    touch /var/run/nginx.pid && \
+    chown nginx:nginx /var/run/nginx.pid
+
+# Switch to unprivileged nginx runtime user
+USER nginx
+
+# Expose unprivileged web port
+EXPOSE 8080
+
+# Run NGINX in foreground
+CMD ["nginx", "-g", "daemon off;"]

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -2,7 +2,7 @@
 okf_version: 0.1
 type: documentation
 title: "CMSForNerd to CMSForNerd2 Static Migration Guide"
-timestamp: "2026-07-30T12:00:00Z"
+timestamp: "2026-07-31T10:00:00Z"
 description: "Comprehensive architectural guide for migrating the database-free flat-file PHP CMS to Astro Static Site Generator (SSG) with HTML5, CSS3, and modern JavaScript."
 topics: [migration, astro, static, php, architecture]
 ---
@@ -229,7 +229,7 @@ With Astro's client-side capabilities, the custom AJAX routing logic is modernis
 
 ## 6. Build & Deployment Architecture
 
-By migrating to static assets, Day 2 operations are massively simplified. High-availability container orchestration (e.g., Podman/Ansible) is replaced or augmented by GitOps-driven deployment.
+By migrating to static assets, Day 2 operations are massively simplified. High-availability container orchestration is replaced or augmented by GitOps-driven deployment.
 
 ### Build Step
 Execute the production build to compile static assets:
@@ -238,27 +238,104 @@ npm run build
 ```
 This writes all HTML, CSS, and JS files to the `dist/` directory, completely self-contained.
 
-### Deploying with Nginx
-For local, on-premise, or VM-based hosting, standardise on an unprivileged, highly-hardened Nginx container config:
+### Deploying to Render.com with NGINX
+To deploy CMSForNerd2 to Render.com, we utilise a secure multi-stage Docker build that compiles our Astro 7.1 application and packages it within a lightweight, unprivileged NGINX Alpine container.
+
+The deployment infrastructure is defined via three root-level files:
+1.  **`render.yaml`** (Blueprint Specification) — Declares a web service using the Docker runtime on the Starter plan in the Singapore region, pointing to `/healthz` for health checks.
+2.  **`Dockerfile`** / **`Containerfile`** — Leverages `node:20-alpine` to compile the static Astro build and then copies the output directory (`dist/`) into an unprivileged `nginx:alpine-slim` runtime.
+3.  **`nginx/nginx.conf`** — Formulates a highly-hardened unprivileged NGINX configuration listening on port `8080`, supporting Clean URLs (routing `/about` to `/about.html` and falling back to `index.html`), gzip compression, and secure HTTP response headers.
+
+### Hardened NGINX Container Configuration
+To satisfy unprivileged execution rules and defend against host compromise, standardise on our hardened `./nginx/nginx.conf`:
 ```nginx
-server {
-    listen 8080 default_server;
-    server_name localhost;
-    root /usr/share/nginx/html;
-    index index.html;
+worker_processes auto;
+pid /tmp/nginx.pid;
 
-    # GZIP Compression
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Logging settings
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
+
+    # Performance optimisation
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    # Gzip compression configuration
     gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml;
+    gzip_disable "msie6";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_min_length 256;
+    gzip_types
+        text/plain
+        text/css
+        application/json
+        application/javascript
+        application/x-javascript
+        text/xml
+        application/xml
+        application/xml+rss
+        text/javascript
+        image/svg+xml;
 
-    # Hardened Security Headers
-    add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self';" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    server {
+        # Port 8080 for unprivileged operation
+        listen 8080 default_server;
+        listen [::]:8080 default_server;
+        server_name _;
 
-    location / {
-        try_files $uri $uri/ /index.html;
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # Custom security headers
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "no-referrer-when-downgrade" always;
+        add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*; connect-src 'self' https://*;" always;
+
+        # Healthcheck location
+        location = /healthz {
+            access_log off;
+            add_header Content-Type text/plain;
+            return 200 "OK";
+        }
+
+        # Handling static assets with caching
+        location /assets/ {
+            expires 1y;
+            add_header Cache-Control "public, no-transform";
+            try_files $uri =404;
+        }
+
+        # Clean URLs routing for Astro static pages
+        location / {
+            try_files $uri $uri/ $uri.html /index.html =404;
+        }
+
+        # Error handling
+        error_page 404 /404.html;
+        location = /404.html {
+            internal;
+        }
+
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+            internal;
+        }
     }
 }
 ```

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,89 @@
+worker_processes auto;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Logging settings
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
+
+    # Performance optimisation
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    # Gzip compression configuration
+    gzip on;
+    gzip_disable "msie6";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_min_length 256;
+    gzip_types
+        text/plain
+        text/css
+        application/json
+        application/javascript
+        application/x-javascript
+        text/xml
+        application/xml
+        application/xml+rss
+        text/javascript
+        image/svg+xml;
+
+    server {
+        # Port 8080 for unprivileged operation
+        listen 8080 default_server;
+        listen [::]:8080 default_server;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # Custom security headers
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "no-referrer-when-downgrade" always;
+        add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*; connect-src 'self' https://*;" always;
+
+        # Healthcheck location
+        location = /healthz {
+            access_log off;
+            add_header Content-Type text/plain;
+            return 200 "OK";
+        }
+
+        # Handling static assets with caching
+        location /assets/ {
+            expires 1y;
+            add_header Cache-Control "public, no-transform";
+            try_files $uri =404;
+        }
+
+        # Clean URLs routing for Astro static pages
+        location / {
+            try_files $uri $uri/ $uri.html /index.html =404;
+        }
+
+        # Error handling
+        error_page 404 /404.html;
+        location = /404.html {
+            internal;
+        }
+
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+            internal;
+        }
+    }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,23 @@
+# ==============================================================================
+# Protocol    : Deep State of Mind (DSOM) For My AI Protocol
+# Author      : Harisfazillah Jamel (LinuxMalaysia)
+# Timestamp   : 2026-07-31
+# License     : GNU General Public License v3.0
+# Standard    : UK English | DBP-standard Bahasa Melayu Malaysia (Piawai)
+# ==============================================================================
+# =============================================================================
+# CMSForNerd2 v2.0.0 - Render Blueprint Specification (render.yaml)
+# Standards: https://render.com/docs/blueprint-spec
+# =============================================================================
+
+services:
+  - type: web
+    name: cmsfornerd2
+    runtime: docker
+    plan: starter
+    region: singapore
+    dockerfilePath: Dockerfile
+    healthCheckPath: /healthz
+    envVars:
+      - key: TZ
+        value: Asia/Kuala_Lumpur


### PR DESCRIPTION
Adopt and customise the containerised deployment configuration for Render.com. We have implemented a root-level render.yaml Blueprint Specification, a multi-stage Dockerfile/Containerfile to compile the static Astro 7.1 build, and a custom unprivileged NGINX configuration listening on port 8080 with a secure /healthz healthcheck endpoint. The migration manuals have also been updated to document this production architecture.

---
*PR created automatically by Jules for task [1414430331900021935](https://jules.google.com/task/1414430331900021935) started by @linuxmalaysia*