### PR TITLE
Adopt for Astro 7.1 and Resolve Peer Dependency Conflicts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/preview_output.log
+++ b/preview_output.log
@@ -1,0 +1,7 @@
+
+> cmsfornerd2@2.0.0 preview
+> astro preview
+
+ astro  v7.1.6 ready in 39 ms
+┃ Local    http://localhost:4321/
+┃ Network  use --host to expose

--- a/public/assets/pwa/router.js
+++ b/public/assets/pwa/router.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
         currentAbortController = new AbortController();
 
         try {
-            // Include a custom header to trigger our new index.php Hydration block
+            // Include a custom header (retained from legacy PHP index.php Hydration block for compatibility)
             const response = await fetch(url, {
                 signal: currentAbortController.signal,
                 headers: {

--- a/src/pages/offline.astro
+++ b/src/pages/offline.astro
@@ -32,7 +32,7 @@ import '../styles/global.css';
   <div class="offline-container">
     <div class="offline-icon">📡❌</div>
     <h1>You're Offline</h1>
-    <p>The <strong>CMSForNerd Laboratory</strong> requires an active internet connection to evaluate dynamic PHP tasks.</p>
+    <p>The <strong>CMSForNerd2</strong> static site is fully self-contained, but some dynamic or external features require an active internet connection.</p>
     <p>Please check your network and try again.</p>
 
     <button onclick="window.location.reload();" style="padding: 10px 20px; font-size: 1rem; cursor: pointer; background-color: #0d6efd; color: white; border: none; border-radius: 5px; margin-top:20px;">

--- a/src/styles/amp.css
+++ b/src/styles/amp.css
@@ -1,5 +1,5 @@
 /* * CMSForNerd Laboratory - AMP Stylesheet
- * Optimized for PHP 8.4 Environment
+ * Adopted for Astro 7.1 Static Site Environment
  */
 
 :root {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -355,7 +355,7 @@ body {
  * [8. RESPONSIVE BRIDGE]
  * Collapses the 3-column grid into a mobile-first stacked view.
  * Educational Note: We change the 'grid-template-areas' and 'grid-template-columns'
- * to reorder content without touching the PHP/HTML source.
+ * to reorder content without touching the Astro/HTML source.
  */
 @media (max-width: 992px) {
     #container {


### PR DESCRIPTION
Adds a root-level .npmrc with legacy-peer-deps=true to bypass ERESOLVE peer conflicts during deployment, and cleans up active non-historical PHP references in stylesheets, offline fallback, and PWA router to fully adopt the Astro 7.1 architecture. All historical educational PHP content has been preserved intact.

---
*PR created automatically by Jules for task [14911063608892206040](https://jules.google.com/task/14911063608892206040) started by @linuxmalaysia*