### PR TITLE
fix: add manual static site deployment instructions in README.md

### DIFF
--- a/.agents/brain/task.md
+++ b/.agents/brain/task.md
@@ -2,7 +2,7 @@
 okf_version: 0.1
 type: task_list
 title: "CMSForNerd2 Active Tasks"
-timestamp: "2026-07-31T14:30:00Z"
+timestamp: "2026-07-31T22:30:00Z"
 description: "Sovereign tracking list of active and completed tasks in this session."
 topics: [tasks, track, progress]
 ---
@@ -21,4 +21,5 @@ topics: [tasks, track, progress]
 - [x] Complete pre-commit checks and verification.
 - [x] Upgrade CMSForNerd2 to Astro 7.1 (specifically "^7.1.6") and verify local build correctness.
 - [x] Resolve Render deployment failure regarding "Publish directory dist/ does not exist!" by adding blueprint configurations and documentation for static site deployments.
+- [x] Document manual static site settings in root README.md to assist users with dashboard configuration.
 - [ ] Submit changes.

--- a/.agents/brain/walkthrough.md
+++ b/.agents/brain/walkthrough.md
@@ -2,7 +2,7 @@
 okf_version: 0.1
 type: walkthrough
 title: "CMSForNerd2 Active Walkthrough"
-timestamp: "2026-07-31T14:30:00Z"
+timestamp: "2026-07-31T22:30:00Z"
 description: "Active record of steps and decisions made during the modernisation of CMSForNerd2."
 topics: [walkthrough, history, brain]
 ---
@@ -18,3 +18,4 @@ topics: [walkthrough, history, brain]
 5.  **Astro v6 Content Collections Refactor**: Migrated `src/content/config.ts` to `src/content.config.ts` with the new glob loader, and refactored `[...slug].astro` and `amp.astro` to call `render(page)` instead of `page.render()`.
 6.  **Visual Verification**: Successfully ran a preview server on port 4321 and used Playwright to generate and inspect a pixel-perfect full-page screenshot of the homepage.
 7.  **Render Deployment Configuration**: Fixed Render deployment issue ("Publish directory dist/ does not exist!" due to skipped build) by adding a static service type configuration in `render.yaml` and documenting the static site deployment steps in `docs/migration-guide.md`.
+8.  **Enhancing Repository Onboarding (README)**: Added clear manual static site deployment instructions in the root `README.md` so that users deploying manually through the Render Dashboard can see how to resolve the empty build command issue immediately.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ npm run build
 ```
 This writes the fully optimised production-ready HTML5, CSS3, and JavaScript files to the dist/ directory, which can be served by any static host or unprivileged web server.
 
+### Deploying to Render.com
+
+CMSForNerd2 can be deployed on **Render.com** either as a containerised service or as a free Static Site.
+
+#### 1. Free Static Site Deployment (Recommended)
+To prevent build failures (such as `Publish directory dist/ does not exist!` due to skipped builds), ensure the following parameters are explicitly configured in the Render Dashboard under your Static Site settings:
+*   **Build Command**: `npm run build`
+*   **Publish Directory**: `dist`
+
+#### 2. Containerised Web Service
+Alternatively, you can deploy using our pre-configured multi-stage Dockerfile and unprivileged NginX server. This can be launched instantly using our Blueprint specification (`render.yaml`).
+
 ---
 *Deep State of Mind (DSOM) For My AI Protocol | Harisfazillah Jamel (LinuxMalaysia) | 2026-07-30*
 *Standard: UK English | DBP-standard Bahasa Melayu Malaysia (Piawai) | GNU General Public License v3.0*


### PR DESCRIPTION
Add clear manual static site deployment instructions in the root README.md to guide users on how to configure the Build Command and Publish Directory within the Render.com Dashboard. This directly prevents build failures due to empty build commands.