### PR TITLE
Fix typo in Windows 11 setup navigation link

### DIFF
--- a/.agents/brain/task.md
+++ b/.agents/brain/task.md
@@ -2,7 +2,7 @@
 okf_version: 0.1
 type: task_list
 title: "CMSForNerd2 Active Tasks"
-timestamp: "2026-07-31T22:30:00Z"
+timestamp: "2026-08-01T01:10:00Z"
 description: "Sovereign tracking list of active and completed tasks in this session."
 topics: [tasks, track, progress]
 ---
@@ -22,4 +22,5 @@ topics: [tasks, track, progress]
 - [x] Upgrade CMSForNerd2 to Astro 7.1 (specifically "^7.1.6") and verify local build correctness.
 - [x] Resolve Render deployment failure regarding "Publish directory dist/ does not exist!" by adding blueprint configurations and documentation for static site deployments.
 - [x] Document manual static site settings in root README.md to assist users with dashboard configuration.
+- [x] Fix typo "(Herd)" to "(Nerd)" in Windows 11 Setup navigation link within `src/components/Navigation.astro`.
 - [ ] Submit changes.

--- a/.agents/brain/walkthrough.md
+++ b/.agents/brain/walkthrough.md
@@ -2,7 +2,7 @@
 okf_version: 0.1
 type: walkthrough
 title: "CMSForNerd2 Active Walkthrough"
-timestamp: "2026-07-31T22:30:00Z"
+timestamp: "2026-08-01T01:10:00Z"
 description: "Active record of steps and decisions made during the modernisation of CMSForNerd2."
 topics: [walkthrough, history, brain]
 ---
@@ -19,3 +19,4 @@ topics: [walkthrough, history, brain]
 6.  **Visual Verification**: Successfully ran a preview server on port 4321 and used Playwright to generate and inspect a pixel-perfect full-page screenshot of the homepage.
 7.  **Render Deployment Configuration**: Fixed Render deployment issue ("Publish directory dist/ does not exist!" due to skipped build) by adding a static service type configuration in `render.yaml` and documenting the static site deployment steps in `docs/migration-guide.md`.
 8.  **Enhancing Repository Onboarding (README)**: Added clear manual static site deployment instructions in the root `README.md` so that users deploying manually through the Render Dashboard can see how to resolve the empty build command issue immediately.
+9.  **Windows 11 Setup Navigation Link Typo Rectification**: Corrected the typo "(Herd)" to "(Nerd)" in the Windows 11 Setup navigation item within `src/components/Navigation.astro` to ensure brand consistency and layout professionalism.

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -9,7 +9,7 @@
     <a href="/template">🎨 Template Guide</a>
     <a href="/sitemap-page">CmsForNerd Sitemap</a>
     <a href="/installation">CmsForNerd Installation</a>
-    <a href="/windows-setup">🪟 Windows 11 Setup (Herd)</a>
+    <a href="/windows-setup">🪟 Windows 11 Setup (Nerd)</a>
     <a href="/welcome-kit">🚀 Student Welcome Kit</a>
     <a href="/history">Modernisation History</a>
     <a href="/lab-manual">🎓 Lab Manual</a>


### PR DESCRIPTION
Rectify typo in the left navigation panel of Navigation.astro where '(Herd)' was written instead of '(Nerd)'. This aligns with the project title CMSForNerd and ensures brand consistency across all laboratory modules.

---
*PR created automatically by Jules for task [4967774015417910310](https://jules.google.com/task/4967774015417910310) started by @linuxmalaysia*