### PR TITLE
Improve GitHub Pages Deployment Pipeline and Website Support

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Site
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'deploy: rebuild GitHub Pages'

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,44 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import AstroPWA from '@vite-pwa/astro';
+import { unified } from '@astrojs/markdown-remark';
+
+const isGitHubPages = process.env.GITHUB_ACTIONS === 'true';
+
+// Custom Rehype plugin to prefix absolute links in Markdown files when deploying to GitHub Pages
+function rehypeAddBase() {
+  const base = isGitHubPages ? '/CMSForNerd2' : '';
+  if (!base || base === '/') {
+    return () => {};
+  }
+  const cleanBase = base.replace(/\/$/, '');
+  return (tree) => {
+    function walk(node) {
+      if (node.type === 'element' && node.tagName === 'a' && node.properties && typeof node.properties.href === 'string') {
+        const href = node.properties.href;
+        if (href.startsWith('/') && !href.startsWith('//')) {
+          node.properties.href = `${cleanBase}${href}`;
+        }
+      }
+      if (node.children) {
+        node.children.forEach(walk);
+      }
+    }
+    walk(tree);
+  };
+}
 
 export default defineConfig({
+  site: isGitHubPages ? 'https://cmsfornerd.github.io' : 'https://cmsfornerd2.netlify.app',
+  base: isGitHubPages ? '/CMSForNerd2' : '/',
   output: 'static',
+  markdown: {
+    processor: unified({
+      rehypePlugins: [
+        rehypeAddBase
+      ]
+    })
+  },
   integrations: [
     mdx(),
     AstroPWA({
@@ -14,7 +49,7 @@ export default defineConfig({
         theme_color: '#0d6efd',
         background_color: '#ffffff',
         display: 'standalone',
-        start_url: '/',
+        start_url: isGitHubPages ? '/CMSForNerd2/' : '/',
         icons: [
           { src: 'assets/pwa/icon-192x192.png', sizes: '192x192', type: 'image/png' },
           { src: 'assets/pwa/icon-512x512.png', sizes: '512x512', type: 'image/png' }

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -1,25 +1,26 @@
 ---
 // src/components/Navigation.astro
+const base = import.meta.env.BASE_URL;
 ---
 <div class="buttonscontainer">
   <div class="buttons">
-    <a href="/">Home</a>
+    <a href={base}>Home</a>
     <a href="https://www.linuxmalaysia.com">CmsForNerd</a>
     <a href="https://github.com/CMSForNerd/CmsForNerd/archive/refs/heads/master.zip">Download</a>
-    <a href="/template">🎨 Template Guide</a>
-    <a href="/sitemap-page">CmsForNerd Sitemap</a>
-    <a href="/installation">CmsForNerd Installation</a>
-    <a href="/windows-setup">🪟 Windows 11 Setup (Nerd)</a>
-    <a href="/welcome-kit">🚀 Student Welcome Kit</a>
-    <a href="/history">Modernisation History</a>
-    <a href="/lab-manual">🎓 Lab Manual</a>
-    <a href="/ai-dev">🤖 AI Development</a>
-    <a href="/ai-sop">📜 AI Ethics SOP</a>
-    <a href="/csp-nonce-guide">🛡️ CSP Nonce Guide</a>
-    <a href="/final-exam">🚩 Final Exam</a>
-    <a href="/graduation">🏁 Graduation</a>
-    <a href="/pwa-architecture">📱 PWA Implementation</a>
-    <a href="/amp-acceleration">⚡ AMP Acceleration</a>
+    <a href={`${base}template`}>🎨 Template Guide</a>
+    <a href={`${base}sitemap-page`}>CmsForNerd Sitemap</a>
+    <a href={`${base}installation`}>CmsForNerd Installation</a>
+    <a href={`${base}windows-setup`}>🪟 Windows 11 Setup (Nerd)</a>
+    <a href={`${base}welcome-kit`}>🚀 Student Welcome Kit</a>
+    <a href={`${base}history`}>Modernisation History</a>
+    <a href={`${base}lab-manual`}>🎓 Lab Manual</a>
+    <a href={`${base}ai-dev`}>🤖 AI Development</a>
+    <a href={`${base}ai-sop`}>📜 AI Ethics SOP</a>
+    <a href={`${base}csp-nonce-guide`}>🛡️ CSP Nonce Guide</a>
+    <a href={`${base}final-exam`}>🚩 Final Exam</a>
+    <a href={`${base}graduation`}>🏁 Graduation</a>
+    <a href={`${base}pwa-architecture`}>📱 PWA Implementation</a>
+    <a href={`${base}amp-acceleration`}>⚡ AMP Acceleration</a>
     <a href="https://www.linuxmalaysia.com">CmsForNerd Blog</a>
   </div>
 </div>

--- a/src/layouts/AmpLayout.astro
+++ b/src/layouts/AmpLayout.astro
@@ -15,6 +15,8 @@ const {
   slug = ""
 } = Astro.props;
 
+const base = import.meta.env.BASE_URL;
+
 // Fetch pages for AMP sidebar navigation, excluding index
 const allPages = await getCollection('pages');
 const ampPages = allPages
@@ -27,7 +29,7 @@ const ampPages = allPages
     let label = p.data.title.split('|')[0].trim();
     return {
       id: p.cleanId,
-      url: `/${p.cleanId}/amp`,
+      url: `${base}${p.cleanId}/amp`,
       label: label
     };
   });
@@ -40,7 +42,7 @@ const ampPages = allPages
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />
     <title>{title} (AMP)</title>
     <meta name="description" content={description} />
-    <link rel="canonical" href={slug === "" || slug === "index" ? "/" : `/${slug}`} />
+    <link rel="canonical" href={slug === "" || slug === "index" ? base : `${base}${slug}`} />
 
     <link rel="dns-prefetch" href="https://cdn.ampproject.org" />
     <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -48,7 +50,7 @@ const ampPages = allPages
     <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
 
     <!-- PWA Foundation -->
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href={`${base}manifest.json`} />
     <meta name="theme-color" content="#0d6efd" />
 
     <style amp-boilerplate is:inline>
@@ -84,7 +86,7 @@ const ampPages = allPages
             </div>
           </li>
           <li>
-            <a href="/amp" class={slug === "" || slug === "index" ? "active" : ""}>
+            <a href={`${base}amp`} class={slug === "" || slug === "index" ? "active" : ""}>
               🏠 Home
             </a>
           </li>
@@ -102,7 +104,7 @@ const ampPages = allPages
     <!-- AMP Header -->
     <header class="amp-header" style="background:var(--lab-bg); padding:10px 15px; border-bottom:1px solid var(--lab-border); display: flex; align-items: center;">
       <button class="hamburger-btn" on="tap:sidebar.toggle" role="button" tabindex="0" aria-label="Open Navigation">☰</button>
-      <a href="/amp" style="text-decoration:none; color:var(--lab-purple); font-weight:bold; flex-grow: 1; margin-left: 10px;">
+      <a href={`${base}amp`} style="text-decoration:none; color:var(--lab-purple); font-weight:bold; flex-grow: 1; margin-left: 10px;">
         🏠 Laboratory Home
       </a>
       <span style="font-family:monospace; font-size:0.7rem; color:var(--lab-muted);">
@@ -119,7 +121,7 @@ const ampPages = allPages
     <footer style="text-align:center; padding:30px; border-top:1px solid var(--lab-border); font-size:0.8rem; color:var(--lab-muted);">
       <p>&copy; 2026 CmsForNerd2 Laboratory</p>
       <p>
-        <a href={slug === "" || slug === "index" ? "/" : `/${slug}`} style="color:var(--lab-purple);">
+        <a href={slug === "" || slug === "index" ? base : `${base}${slug}`} style="color:var(--lab-purple);">
           Switch to Standard Desktop View
         </a>
       </p>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,6 +20,8 @@ const {
   slug = ""
 } = Astro.props;
 
+const base = import.meta.env.BASE_URL;
+
 // Fetch pages for dynamic footer navigation, excluding index and some other helper files
 const allPages = await getCollection('pages');
 const footerPages = allPages
@@ -32,7 +34,7 @@ const footerPages = allPages
     let label = p.data.title.split('|')[0].trim();
     return {
       id: p.cleanId,
-      url: `/${p.cleanId}`,
+      url: `${base}${p.cleanId}`,
       label: label
     };
   });
@@ -46,8 +48,8 @@ const footerPages = allPages
     <title>{title}</title>
     <meta name="description" content={description} />
     <meta name="theme-color" content="#0d6efd" />
-    <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="manifest" href={`${base}manifest.json`} />
+    <link rel="icon" type="image/x-icon" href={`${base}favicon.ico`} />
 
     <!-- Schema.org JSON-LD structured data -->
     <script type="application/ld+json" is:inline set:html={JSON.stringify({
@@ -129,7 +131,7 @@ const footerPages = allPages
             </p>
 
             <div style="display: flex; justify-content: center; gap: 18px; flex-wrap: wrap; margin-bottom: 10px;">
-              <a href="/" style="color: var(--lab-highlight, #8e44ad); text-decoration: none; font-weight: 700;">Home</a>
+              <a href={base} style="color: var(--lab-highlight, #8e44ad); text-decoration: none; font-weight: 700;">Home</a>
               {footerPages.map(page => (
                 <a href={page.url} style="color: inherit; text-decoration: none; font-size: 0.9rem; border-bottom: 1px solid rgba(0,0,0,0.1); padding-bottom: 2px;">{page.label}</a>
               ))}
@@ -139,7 +141,7 @@ const footerPages = allPages
           <hr style="width: 60px; border: 0; border-top: 3px solid var(--lab-highlight, #8e44ad); margin: 25px auto; opacity: 0.6;" />
 
           <div style="margin-bottom: 20px;">
-            <a href={slug === "" || slug === "index" ? "/amp" : `/${slug}/amp`}
+            <a href={slug === "" || slug === "index" ? `${base}amp` : `${base}${slug}/amp`}
                style="display: inline-block; padding: 5px 12px; border: 1px solid var(--lab-highlight, #8e44ad); border-radius: 4px; color: var(--lab-highlight, #8e44ad); text-decoration: none; font-size: 0.75rem; font-family: 'SF Mono', monospace; font-weight: bold;">
                ⚡ SWITCH TO AMP MOBILE VIEW
             </a>
@@ -160,7 +162,7 @@ const footerPages = allPages
         </div>
 
         <div class="sitemap-link" style="margin-top:10px;">
-          <a href="/sitemap.xml" target="_blank">[XML Sitemap]</a>
+          <a href={`${base}sitemap.xml`} target="_blank">[XML Sitemap]</a>
         </div>
 
         <div style="margin-top: 5px; font-size: 0.7em; opacity: 0.5;">


### PR DESCRIPTION
This change adds support for building and deploying the modern Astro 7.1 SSG website of CMSForNerd2 directly to GitHub Pages. It configures base and site attributes dynamically in astro.config.mjs based on whether it is running inside GitHub Actions. Furthermore, a custom Rehype post-processing plugin was written to rewrite absolute paths inside Markdown content automatically during compile time. Finally, the Navigation component and the layouts were updated to utilize import.meta.env.BASE_URL. A GitHub Actions pipeline was configured to build and deploy to the gh-pages branch on every push to master.

---
*PR created automatically by Jules for task [3431836558670417081](https://jules.google.com/task/3431836558670417081) started by @linuxmalaysia*