### PR TITLE
🧹 Centralize dynamic navigation mapping and remove duplicated slug purification

### DIFF
--- a/src/layouts/AmpLayout.astro
+++ b/src/layouts/AmpLayout.astro
@@ -1,7 +1,7 @@
 ---
 // src/layouts/AmpLayout.astro
-import { getCollection } from 'astro:content';
 import ampCss from '../styles/amp.css?raw';
+import { getNavigationPages } from '../utils/navigation';
 
 interface Props {
   title?: string;
@@ -17,22 +17,8 @@ const {
 
 const base = import.meta.env.BASE_URL;
 
-// Fetch pages for AMP sidebar navigation, excluding index
-const allPages = await getCollection('pages');
-const ampPages = allPages
-  .map(p => {
-    const cleanId = p.id.replace(/\.[^/.]+$/, "");
-    return { ...p, cleanId };
-  })
-  .filter(p => p.cleanId !== 'index')
-  .map(p => {
-    let label = p.data.title.split('|')[0].trim();
-    return {
-      id: p.cleanId,
-      url: `${base}${p.cleanId}/amp`,
-      label: label
-    };
-  });
+// Fetch cleanly formatted pages for AMP sidebar navigation using central helper
+const ampPages = await getNavigationPages(base, true);
 ---
 
 <!doctype html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,9 +1,9 @@
 ---
 // src/layouts/Layout.astro
-import { getCollection } from 'astro:content';
 import { ClientRouter } from 'astro:transitions';
 import Navigation from '../components/Navigation.astro';
 import Widgets from '../components/Widgets.astro';
+import { getNavigationPages } from '../utils/navigation';
 import '../styles/global.css';
 
 interface Props {
@@ -22,22 +22,8 @@ const {
 
 const base = import.meta.env.BASE_URL;
 
-// Fetch pages for dynamic footer navigation, excluding index and some other helper files
-const allPages = await getCollection('pages');
-const footerPages = allPages
-  .map(p => {
-    const cleanId = p.id.replace(/\.[^/.]+$/, "");
-    return { ...p, cleanId };
-  })
-  .filter(p => p.cleanId !== 'index')
-  .map(p => {
-    let label = p.data.title.split('|')[0].trim();
-    return {
-      id: p.cleanId,
-      url: `${base}${p.cleanId}`,
-      label: label
-    };
-  });
+// Fetch cleanly formatted pages for dynamic footer navigation using central helper
+const footerPages = await getNavigationPages(base, false);
 ---
 
 <!doctype html>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,12 +1,13 @@
 ---
 import { getCollection, render } from 'astro:content';
 import Layout from '../layouts/Layout.astro';
+import { getCleanSlug } from '../utils/navigation';
 
 export async function getStaticPaths() {
   const pages = await getCollection('pages');
   return pages.map(page => {
     // Strip file extensions to match clean slug structure
-    const cleanId = page.id.replace(/\.[^/.]+$/, "");
+    const cleanId = getCleanSlug(page.id);
     const slug = cleanId === 'index' ? undefined : cleanId;
     return {
       params: { slug },
@@ -17,7 +18,7 @@ export async function getStaticPaths() {
 
 const { page } = Astro.props;
 const { Content } = await render(page);
-const slugValue = page.id.replace(/\.[^/.]+$/, "");
+const slugValue = getCleanSlug(page.id);
 ---
 
 <Layout

--- a/src/pages/[...slug]/amp.astro
+++ b/src/pages/[...slug]/amp.astro
@@ -1,12 +1,13 @@
 ---
 import { getCollection, render } from 'astro:content';
 import AmpLayout from '../../layouts/AmpLayout.astro';
+import { getCleanSlug } from '../../utils/navigation';
 
 export async function getStaticPaths() {
   const pages = await getCollection('pages');
   return pages.map(page => {
     // Strip file extensions to match clean slug structure
-    const cleanId = page.id.replace(/\.[^/.]+$/, "");
+    const cleanId = getCleanSlug(page.id);
     const slug = cleanId === 'index' ? undefined : cleanId;
     return {
       params: { slug },
@@ -17,7 +18,7 @@ export async function getStaticPaths() {
 
 const { page } = Astro.props;
 const { Content } = await render(page);
-const slugValue = page.id.replace(/\.[^/.]+$/, "");
+const slugValue = getCleanSlug(page.id);
 ---
 
 <AmpLayout

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,11 +1,12 @@
 import { getCollection } from 'astro:content';
+import { getCleanSlug } from '../utils/navigation';
 
 export async function GET() {
   const pages = await getCollection('pages');
   const baseUrl = 'https://cmsfornerd2.netlify.app'; // Fallback base URL
 
   const urlElements = pages.map(page => {
-    const cleanId = page.id.replace(/\.[^/.]+$/, "");
+    const cleanId = getCleanSlug(page.id);
     const slugPath = cleanId === 'index' ? '' : `${cleanId}`;
     const standardUrl = `${baseUrl}/${slugPath}`;
     const ampUrl = `${baseUrl}/${cleanId === 'index' ? 'amp' : `${cleanId}/amp`}`;

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,49 @@
+import { getCollection } from 'astro:content';
+
+/**
+ * Strips file extensions from content collection item IDs to match clean slug structure.
+ *
+ * @param id The original content ID (e.g. 'index.md', 'about.md')
+ * @returns A clean slug (e.g. 'index', 'about')
+ */
+export function getCleanSlug(id: string): string {
+  return id.replace(/\.[^/.]+$/, "");
+}
+
+interface NavigationPage {
+  id: string;
+  url: string;
+  label: string;
+}
+
+/**
+ * Fetches, cleans, and formats navigation-ready page lists for the layouts,
+ * avoiding duplicate rendering and manual page ID manipulation in templates.
+ *
+ * @param base The dynamic BASE_URL prefix (e.g. '/CMSForNerd2/' or '/')
+ * @param isAmp Whether to format URL paths for Accelerated Mobile Pages (AMP)
+ * @returns A list of cleanly formatted navigation items
+ */
+export async function getNavigationPages(base: string, isAmp = false): Promise<NavigationPage[]> {
+  const allPages = await getCollection('pages');
+
+  return allPages
+    .map(page => {
+      const cleanId = getCleanSlug(page.id);
+      return { ...page, cleanId };
+    })
+    .filter(page => page.cleanId !== 'index')
+    .map(page => {
+      // Split on '|' to extract the human-readable display title, e.g. "About | CmsForNerd" -> "About"
+      const label = page.data.title.split('|')[0].trim();
+
+      const suffix = isAmp ? '/amp' : '';
+      const url = `${base}${page.cleanId}${suffix}`;
+
+      return {
+        id: page.cleanId,
+        url,
+        label
+      };
+    });
+}


### PR DESCRIPTION
🎯 What: Addressed code health issues by extracting duplicated content ID-to-slug purification and dynamic navigation pages mapping logic from multiple template and layout files into a centralized helper utility (`src/utils/navigation.ts`).

💡 Why: This significantly improves the codebase's maintainability and readability. Layouts (`Layout.astro`, `AmpLayout.astro`), page routes (`[...slug].astro`, `[...slug]/amp.astro`), and `sitemap.xml.ts` now consume the unified helpers `getCleanSlug` and `getNavigationPages`, preventing logic drift.

✅ Verification: Verified the code changes by running `npm run build`, compiling all static assets completely with zero errors. All original behaviors, metadata, and functionality are fully preserved.

---
*PR created automatically by Jules for task [12466558591841857097](https://jules.google.com/task/12466558591841857097) started by @linuxmalaysia*