### PR TITLE
Upgrade Node.js to v22 for Astro Compatibility

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install Dependencies

--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,7 @@
 # =============================================================================
 
 # Stage 1: Build environment
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # =============================================================================
 
 # Stage 1: Build environment
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -252,7 +252,7 @@ To deploy CMSForNerd2 to Render.com, we utilise a secure multi-stage Docker buil
 
 The deployment infrastructure is defined via three root-level files:
 1.  **`render.yaml`** (Blueprint Specification) — Declares a web service using the Docker runtime on the Starter plan in the Singapore region, pointing to `/healthz` for health checks.
-2.  **`Dockerfile`** / **`Containerfile`** — Leverages `node:20-alpine` to compile the static Astro build and then copies the output directory (`dist/`) into an unprivileged `nginx:alpine-slim` runtime.
+2.  **`Dockerfile`** / **`Containerfile`** — Leverages `node:22-alpine` to compile the static Astro build and then copies the output directory (`dist/`) into an unprivileged `nginx:alpine-slim` runtime.
 3.  **`nginx/nginx.conf`** — Formulates a highly-hardened unprivileged NGINX configuration listening on port `8080`, supporting Clean URLs (routing `/about` to `/about.html` and falling back to `index.html`), gzip compression, and secure HTTP response headers.
 
 ### Hardened NGINX Container Configuration

--- a/preview_output.log
+++ b/preview_output.log
@@ -2,6 +2,6 @@
 > cmsfornerd2@2.0.0 preview
 > astro preview
 
- astro  v7.1.6 ready in 39 ms
+ astro  v7.1.6 ready in 36 ms
 ┃ Local    http://localhost:4321/
 ┃ Network  use --host to expose

--- a/src/content/pages/ansible-lab.md
+++ b/src/content/pages/ansible-lab.md
@@ -42,7 +42,7 @@ topics: ["modernisation", "astro", "static", "architecture"]
 <div class="proc-card">
 <h3>🟢 Node.js & npm</h3>
 <ul>
-<li>Secure installation of Node.js v20+ and npm runtime.</li>
+<li>Secure installation of Node.js v22+ and npm runtime.</li>
 <li>Build cache optimizations to speed up compilation.</li>
 <li>TypeScript support for compile-time Zod validations.</li>
 </ul>

--- a/src/content/pages/index.md
+++ b/src/content/pages/index.md
@@ -82,7 +82,7 @@ While frameworks often hide complexity, we expose it—teaching you to master mo
 <table class="stack-table">
 <tr>
 <td><strong>Runtime/Framework</strong></td>
-<td>Astro 7.1 (using Node.js 20+ and static output)</td>
+<td>Astro 7.1 (using Node.js 22+ and static output)</td>
 </tr>
 <tr>
 <td><strong>Standards</strong></td>

--- a/src/content/pages/installation.md
+++ b/src/content/pages/installation.md
@@ -22,7 +22,7 @@ The modernization ensures full cross-platform compatibility across Windows, Linu
 
 <h3>Requirements</h3>
 <ul>
-<li><strong>Runtime Environment:</strong> Node.js v20+ (LTS recommended).</li>
+<li><strong>Runtime Environment:</strong> Node.js v22+ (LTS recommended).</li>
 <li><strong>Dependency Manager:</strong> npm (v10+).</li>
 <li><strong>Version Control:</strong> Git.</li>
 <li><strong>No Database or PHP runtime required at all!</strong></li>

--- a/src/content/pages/lab-module3.md
+++ b/src/content/pages/lab-module3.md
@@ -77,7 +77,7 @@ add_header Referrer-Policy "strict-origin-when-cross-origin" always;</code></pre
 <p>Notice how our build process compiling Astro 7.1 separates the build tools from the final NGINX container:</p>
 <div class="code-block modern">
 <pre><code># Stage 1: Build the static files
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm install --legacy-peer-deps

--- a/src/content/pages/linux-setup.md
+++ b/src/content/pages/linux-setup.md
@@ -2,7 +2,7 @@
 okf_version: 0.1
 type: "content_page"
 title: "Linux Setup Guide (Node.js & Astro) | CMSForNerd2 Lab"
-description: "Official laboratory guide for installing Node.js 20+ and Astro 7.1 on Debian, Ubuntu LTS, and AlmaLinux."
+description: "Official laboratory guide for installing Node.js 22+ and Astro 7.1 on Debian, Ubuntu LTS, and AlmaLinux."
 schemaType: "HowTo"
 author: "CMSForNerd Team & Google Gemini"
 timestamp: "2026-07-30T12:00:00Z"
@@ -12,11 +12,11 @@ topics: ["modernisation", "astro", "static", "architecture"]
 <article class="lab-worksheet linux-setup" itemscope itemtype="https://schema.org/HowTo">
 <header class="setup-header">
 <h1 itemprop="name">🐧 Linux Setup Guide: Laboratory Readiness</h1>
-<p class="subtitle">Ensuring Node.js 20+ & Astro 7.1 Compatibility on Debian, Ubuntu LTS & AlmaLinux</p>
+<p class="subtitle">Ensuring Node.js 22+ & Astro 7.1 Compatibility on Debian, Ubuntu LTS & AlmaLinux</p>
 </header>
 
 <div class="requirement-alert" role="alert">
-<strong>RFC 2119 REQUIRED:</strong> To complete the laboratory modules, your development environment <strong>MUST</strong> run <strong>Node.js 20.0</strong> or higher to compile Astro 7.1.
+<strong>RFC 2119 REQUIRED:</strong> To complete the laboratory modules, your development environment <strong>MUST</strong> run <strong>Node.js 22.0</strong> or higher to compile Astro 7.1.
 </div>
 
 <section class="os-selector">
@@ -28,7 +28,7 @@ topics: ["modernisation", "astro", "static", "architecture"]
 <code># Install dependencies
 sudo apt update && sudo apt install -y curl ca-certificates gnupg git
 # Add NodeSource GPG Key and Repo
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 # Install Node.js
 sudo apt update && sudo apt install -y nodejs
 # Verify installations
@@ -38,12 +38,12 @@ node -v && npm -v</code>
 
 <div class="os-block almalinux" itemprop="step">
 <h2>📦 Option B: AlmaLinux (9+)</h2>
-<p>Using the official DNF module streams to enable Node.js 20 on Red Hat-based environments.</p>
+<p>Using the official DNF module streams to enable Node.js 22 on Red Hat-based environments.</p>
 
 <div class="terminal-block">
-<code># Enable Node.js 20 stream
+<code># Enable Node.js 22 stream
 sudo dnf module reset nodejs -y
-sudo dnf module enable nodejs:20 -y
+sudo dnf module enable nodejs:22 -y
 # Install Node.js, npm, and git
 sudo dnf install -y nodejs npm git
 # Verify installations
@@ -72,7 +72,7 @@ npm run dev</code>
 <h2>🎓 Linux Compliance Summary</h2>
 <ul>
 <li><strong>MUST:</strong> Deliver all package updates and npm commands via secure channels.</li>
-<li><strong>REQUIRED:</strong> Run Node.js v20.0 or higher.</li>
+<li><strong>REQUIRED:</strong> Run Node.js v22.0 or higher.</li>
 <li><strong>SHOULD:</strong> Leverage Visual Studio Code with official Astro language extension support.</li>
 </ul>
 </footer>

--- a/src/content/pages/windows-setup.md
+++ b/src/content/pages/windows-setup.md
@@ -30,7 +30,7 @@ modern TypeScript and unprivileged container standards. By focusing on static op
 <h3>1. Node.js (The Static Compilation Engine)</h3>
 <p>Node.js is the preferred runtime environment because it executes the Astro compiler locally to render pages.</p>
 <ul>
-<li><strong>Download:</strong> Visit <a href="https://nodejs.org" target="_blank">nodejs.org</a> and download the v20 LTS installer.</li>
+<li><strong>Download:</strong> Visit <a href="https://nodejs.org" target="_blank">nodejs.org</a> and download the v22 LTS installer.</li>
 <li><strong>Version Selection:</strong> During setup, ensure you select the standard LTS package.</li>
 <li><strong>npm integration:</strong> The installer automatically bundles <code>npm</code>, our package and integration manager.</li>
 </ul>
@@ -76,7 +76,7 @@ modern TypeScript and unprivileged container standards. By focusing on static op
 </li>
 <li>Verify Node Version:
 <div class="terminal-block"><code>node -v</code></div>
-<p>Ensure it says <strong>v20.x.x</strong> or higher.</p>
+<p>Ensure it says <strong>v22.x.x</strong> or higher.</p>
 </li>
 </ol>
 </section>


### PR DESCRIPTION
This branch resolves the Astro compatibility issue with Node.js version 20 in the CI environment. The Astro 7.1 compiler requires Node.js >=22.12.0. This PR updates the GitHub Actions deploy-gh-pages.yml workflow to use Node.js version 22, upgrades Dockerfile and Containerfile builder images to node:22-alpine, and modernizes all installation/setup/laboratory guide documents across the repository to instruct students and developers on using Node.js v22+.

---
*PR created automatically by Jules for task [12734532412844106872](https://jules.google.com/task/12734532412844106872) started by @linuxmalaysia*