### PR TITLE
🧹 [layout environment version corrected to ASTRO_7]

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -143,7 +143,7 @@ const footerPages = await getNavigationPages(base, false);
           </div>
 
           <div style="font-family: 'SF Mono', monospace; font-size: 0.65rem; color: #94a3b8; margin-top: 30px; letter-spacing: 0.5px;">
-            [ REL: 3.5.1 ] | [ STD: RFC_9116 ] | [ ENV: ASTRO_5 ] | [ VIEW: STANDARD ]
+            [ REL: 3.5.1 ] | [ STD: RFC_9116 ] | [ ENV: ASTRO_7 ] | [ VIEW: STANDARD ]
           </div>
         </div>
 


### PR DESCRIPTION
Corrected outdated environment label in layout metadata to accurately reflect upgraded Astro version in layout footer.

---
*PR created automatically by Jules for task [3503493801027726633](https://jules.google.com/task/3503493801027726633) started by @linuxmalaysia*